### PR TITLE
Integrate Gemini as a new LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 # Model provider configuration
+# Options: openai, gemini
+MODEL_PROVIDER=openai
 API_KEY=
 API_BASE=http://mockserver:8090/v1
 

--- a/backend/app/infrastructure/config.py
+++ b/backend/app/infrastructure/config.py
@@ -5,6 +5,7 @@ from functools import lru_cache
 class Settings(BaseSettings):
     
     # Model provider configuration
+    model_provider: str = "openai"  # "openai" or "gemini"
     api_key: str | None = None
     api_base: str = "https://api.deepseek.com/v1"
     

--- a/backend/app/infrastructure/external/browser/playwright_browser.py
+++ b/backend/app/infrastructure/external/browser/playwright_browser.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, Optional, List
 from playwright.async_api import async_playwright, Browser, Page
 import asyncio
 from markdownify import markdownify
-from app.infrastructure.external.llm.openai_llm import OpenAILLM
+from app.infrastructure.external.llm import get_llm
 from app.infrastructure.config import get_settings
 from app.domain.models.tool_result import ToolResult
 import logging
@@ -17,7 +17,7 @@ class PlaywrightBrowser:
         self.browser: Optional[Browser] = None
         self.page: Optional[Page] = None
         self.playwright = None
-        self.llm = OpenAILLM()
+        self.llm = get_llm()
         self.settings = get_settings()
         self.cdp_url = cdp_url
         

--- a/backend/app/infrastructure/external/llm/__init__.py
+++ b/backend/app/infrastructure/external/llm/__init__.py
@@ -1,0 +1,18 @@
+from app.infrastructure.config import get_settings
+from app.domain.external.llm import LLM
+from app.infrastructure.external.llm.openai_llm import OpenAILLM
+from app.infrastructure.external.llm.gemini_llm import GeminiLLM
+
+def get_llm() -> LLM:
+    """
+    Returns an instance of the LLM based on the provider specified in the settings.
+    """
+    settings = get_settings()
+    provider = getattr(settings, 'model_provider', 'openai')
+
+    if provider == 'gemini':
+        return GeminiLLM()
+    elif provider == 'openai':
+        return OpenAILLM()
+    else:
+        raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/backend/app/infrastructure/external/llm/gemini_llm.py
+++ b/backend/app/infrastructure/external/llm/gemini_llm.py
@@ -1,0 +1,66 @@
+from typing import List, Dict, Any, Optional
+import google.generativeai as genai
+from app.domain.external.llm import LLM
+from app.infrastructure.config import get_settings
+import logging
+
+logger = logging.getLogger(__name__)
+
+class GeminiLLM(LLM):
+    def __init__(self):
+        settings = get_settings()
+        self.api_key = settings.api_key
+
+        # Configure the generative AI client
+        genai.configure(api_key=self.api_key)
+
+        self._model_name = settings.model_name
+        self._temperature = settings.temperature
+        self._max_tokens = settings.max_tokens
+
+        # Create the generative model instance
+        self.model = genai.GenerativeModel(self._model_name)
+
+        logger.info(f"Initialized Gemini LLM with model: {self._model_name}")
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def temperature(self) -> float:
+        return self._temperature
+
+    @property
+    def max_tokens(self) -> int:
+        return self._max_tokens
+
+    async def ask(self, messages: List[Dict[str, str]],
+                tools: Optional[List[Dict[str, Any]]] = None,
+                response_format: Optional[Dict[str, Any]] = None,
+                tool_choice: Optional[str] = None) -> Dict[str, Any]:
+        """Send chat request to Gemini API"""
+        try:
+            # Create the generation configuration
+            generation_config = genai.types.GenerationConfig(
+                temperature=self._temperature,
+                max_output_tokens=self._max_tokens
+            )
+
+            # Send the request to the model
+            response = self.model.generate_content(
+                contents=messages,
+                generation_config=generation_config,
+                tools=tools
+            )
+
+            # Extract the response data
+            response_data = {
+                "role": response.candidates[0].content.role,
+                "content": response.candidates[0].content.parts[0].text
+            }
+
+            return response_data
+        except Exception as e:
+            logger.error(f"Error calling Gemini API: {str(e)}")
+            raise

--- a/backend/app/infrastructure/utils/llm_json_parser.py
+++ b/backend/app/infrastructure/utils/llm_json_parser.py
@@ -5,7 +5,7 @@ from enum import Enum
 import logging
 
 from app.domain.utils.json_parser import JsonParser
-from app.infrastructure.external.llm.openai_llm import OpenAILLM
+from app.infrastructure.external.llm import get_llm
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ class LLMJsonParser(JsonParser):
     """
     
     def __init__(self):
-        self.llm = OpenAILLM()
+        self.llm = get_llm()
         self.strategies = [
             self._try_direct_parse,
             self._try_markdown_block_parse,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from app.infrastructure.storage.mongodb import get_mongodb
 from app.infrastructure.storage.redis import get_redis
 from app.infrastructure.external.search.google_search import GoogleSearchEngine
 from app.infrastructure.external.search.baidu_search import BaiduSearchEngine
-from app.infrastructure.external.llm.openai_llm import OpenAILLM
+from app.infrastructure.external.llm import get_llm
 from app.infrastructure.external.sandbox.docker_sandbox import DockerSandbox
 from app.infrastructure.external.file.gridfsfile import GridFSFileStorage
 from app.infrastructure.repositories.mongo_agent_repository import MongoAgentRepository
@@ -58,7 +58,7 @@ def create_agent_service() -> AgentService:
         logger.warning(f"Unknown search provider: {settings.search_provider}")
 
     return AgentService(
-        llm=OpenAILLM(),
+        llm=get_llm(),
         agent_repository=MongoAgentRepository(),
         session_repository=MongoSessionRepository(),
         sandbox_cls=DockerSandbox,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 openai
+google-generativeai
 pydantic
 pydantic-settings
 python-dotenv


### PR DESCRIPTION
I have introduced support for Google's Gemini as a new LLM provider, alongside the existing OpenAI provider.

Key changes:
- Added `google-generativeai` to the list of dependencies.
- Implemented a `GeminiLLM` class that conforms to the existing `LLM` protocol.
- Introduced a `MODEL_PROVIDER` configuration option to allow you to switch between `openai` and `gemini`.
- Created a factory function `get_llm()` to dynamically instantiate the appropriate LLM based on the configuration.
- Refactored the application to use the `get_llm()` factory, decoupling the code from a specific LLM implementation.
- Updated the example environment file to include the new `MODEL_PROVIDER` option.